### PR TITLE
Typo in metal generation

### DIFF
--- a/scripts/materials.js
+++ b/scripts/materials.js
@@ -293,7 +293,7 @@ class Metal {
         output += `\n[BUILDING:SMELTER:NONE]`;
         output += `\n[REAGENT:A:150:BAR:NO_SUBTYPE:METAL:${this.precursor.name.toUpperCase()}]`;
         if (this.extra_ingredient == 'flux') {
-          output += `\n[REAGENT:B:1:BOULDER:NO_SUBTYPE:NONE:NONE][REACION_CLASS:FLUX]`;
+          output += `\n[REAGENT:B:1:BOULDER:NO_SUBTYPE:NONE:NONE][REACTION_CLASS:FLUX]`;
         } else {
             output += `\n[REAGENT:B:1:BOULDER:NO_SUBTYPE:INORGANIC:${this.extra_ingredient.toUpperCase()}]`;
         }


### PR DESCRIPTION
Fixed a typo which would generate an erroneous raw entry for flux containing alloys.